### PR TITLE
JS: Using window.addEventListener

### DIFF
--- a/modules/paymill/javascript/Payment.js
+++ b/modules/paymill/javascript/Payment.js
@@ -1,6 +1,6 @@
 var prefilledInputValues = [];
 
-window.onload = function() {
+var paymillInit = function() {
     prefilledInputValues = getFormData();
 
     /**
@@ -294,3 +294,10 @@ window.onload = function() {
     }
 
 };
+
+
+if (window.addEventListener){
+    window.addEventListener("load", paymillInit);
+} else if (window.attachEvent){
+    window.attachEvent("onload", paymillInit);
+} else window.onload = paymillInit;


### PR DESCRIPTION
Overriding window.onload leads to conflicts with other JS scripts doing the same thing (e.g. Google Analytics). Only the last function assigned via window.onload = function(){…} will be triggered.

window.addEventListener (or attachEvent for IE < 8) is a clean solution for adding more than one function to the load event.
